### PR TITLE
#1 - Allow multiple idp's with the same metadatalink

### DIFF
--- a/classes/admin/setting_idpmetadata.php
+++ b/classes/admin/setting_idpmetadata.php
@@ -90,7 +90,7 @@ class setting_idpmetadata extends admin_setting_configtextarea {
                 $oldidps[$idpentity->metadataurl] = array();
             }
 
-            $oldidps[$idpentity->metadataurl][$idpentity->entityid] = $idpentity;
+            $oldidps[$idpentity->metadataurl][$idpentity->id] = $idpentity;
         }
 
         foreach ($idps as $idp) {

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -123,7 +123,6 @@ class auth extends \auth_plugin_base {
         foreach ($idpentities as $idpentity) {
             // Set name.
             $idpentity->name = empty($idpentity->displayname) ? $idpentity->defaultname : $idpentity->displayname;
-            $idpentity->md5id = md5($idpentity->entityid);
             $idpentity->md5id = md5($idpentity->id);
             // Set default IdP if we found one.
             if ((bool) $idpentity->defaultidp && !isset($this->defaultidp)) {

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -123,12 +123,13 @@ class auth extends \auth_plugin_base {
         foreach ($idpentities as $idpentity) {
             // Set name.
             $idpentity->name = empty($idpentity->displayname) ? $idpentity->defaultname : $idpentity->displayname;
-            $idpentity->md5entityid = md5($idpentity->entityid);
+            $idpentity->md5id = md5($idpentity->entityid);
+            $idpentity->md5id = md5($idpentity->id);
             // Set default IdP if we found one.
             if ((bool) $idpentity->defaultidp && !isset($this->defaultidp)) {
                 $this->defaultidp = $idpentity;
             }
-            $this->metadataentities[$idpentity->md5entityid] = $idpentity;
+            $this->metadataentities[$idpentity->md5id] = $idpentity;
         }
 
         // Check if we have mutiple IdPs configured.
@@ -252,7 +253,7 @@ class auth extends \auth_plugin_base {
             // Moodle Workplace - Check IdP's tenant availability.
             // Check if function exists required for Totara 12 compatibility.
             if (class_exists(\tool_tenant\local\auth\saml2\manager::class) && !component_class_callback('\tool_tenant\local\auth\saml2\manager',
-                    'issuer_available', [$idp->md5entityid], true)) {
+                    'issuer_available', [$idp->md5id], true)) {
                 continue;
             }
 
@@ -260,7 +261,7 @@ class auth extends \auth_plugin_base {
             if (strpos($wantsurl, '/auth/saml2/login.php') !== false) {
                 $idpurl = new moodle_url($wantsurl);
             } else {
-                $idpurl = new moodle_url('/auth/saml2/login.php', ['wants' => $wantsurl, 'idp' => $idp->md5entityid]);
+                $idpurl = new moodle_url('/auth/saml2/login.php', ['wants' => $wantsurl, 'idp' => $idp->md5id]);
             }
             $idpurl->param('passive', 'off');
 
@@ -558,7 +559,7 @@ class auth extends \auth_plugin_base {
         require_once("$CFG->dirroot/login/lib.php");
 
         // Set the default IdP to be the first in the list. Used when dual login is disabled.
-        $SESSION->saml2idp = reset($this->metadataentities)->md5entityid;
+        $SESSION->saml2idp = reset($this->metadataentities)->md5id;
 
         // We store the IdP in the session to generate the config/config.php array with the default local SP.
         $idpalias = optional_param('idpalias', '', PARAM_TEXT);
@@ -567,7 +568,7 @@ class auth extends \auth_plugin_base {
 
             foreach ($this->metadataentities as $idpentity) {
                 if ($idpalias == $idpentity->alias) {
-                    $SESSION->saml2idp = $idpentity->md5entityid;
+                    $SESSION->saml2idp = $idpentity->md5id;
                     $idpfound = true;
                     break;
                 }
@@ -579,7 +580,7 @@ class auth extends \auth_plugin_base {
         } else if (isset($_GET['idp'])) {
             $SESSION->saml2idp = $_GET['idp'];
         } else if (!is_null($this->defaultidp)) {
-            $SESSION->saml2idp = $this->defaultidp->md5entityid;
+            $SESSION->saml2idp = $this->defaultidp->md5id;
         } else if ($this->multiidp) {
             // At this stage there is no alias, get-param or default IdP configured.
             // On a multi-idp system, now check for any whitelisted IP address redirection.
@@ -863,7 +864,7 @@ class auth extends \auth_plugin_base {
     protected function check_whitelisted_ip_redirect() {
         foreach ($this->metadataentities as $idpentity) {
             if (\core\ip_utils::is_ip_in_subnet_list(getremoteaddr(), $idpentity->whitelist ?? '')) {
-                return $idpentity->md5entityid;
+                return $idpentity->md5id;
             }
         }
         return false;

--- a/classes/auto_login.php
+++ b/classes/auto_login.php
@@ -157,7 +157,7 @@ class auto_login {
         $auth = get_auth_plugin('saml2');
 
         // Set the default IdP to be the first in the list. Used when dual login is disabled.
-        $SESSION->saml2idp = reset($auth->metadataentities)->md5entityid;
+        $SESSION->saml2idp = reset($auth->metadataentities)->md5id;
 
         // Target URL is normally the same as current page, but if we got redirected to enrol.php
         // with a 'wants' URL, then that means if the login is successful we should try again at

--- a/classes/form/testidpselect.php
+++ b/classes/form/testidpselect.php
@@ -50,7 +50,7 @@ class testidpselect extends moodleform {
         $metadataentities = $this->_customdata['metadataentities'];
         $selectvalues = [];
         foreach ($metadataentities as $idpentity) {
-            $selectvalues[$idpentity->md5entityid] = "{$idpentity->metadataurl} ({$idpentity->name})";
+            $selectvalues[$idpentity->md5id] = "{$idpentity->metadataurl} ({$idpentity->name})";
         }
 
         $mform->addElement('select', 'idp', get_string('test_auth_button_login', 'auth_saml2'), $selectvalues);

--- a/locallib.php
+++ b/locallib.php
@@ -427,13 +427,13 @@ function auth_saml2_get_idps($active = false, $asarray = false) {
 
     foreach ($idpentitiesrs as $idpentity) {
         $idpentity->name = empty($idpentity->displayname) ? $idpentity->defaultname : $idpentity->displayname;
-        $idpentity->md5entityid = md5($idpentity->entityid);
+        $idpentity->md5id = md5($idpentity->id);
 
         if (!isset($idpentities[$idpentity->metadataurl])) {
             $idpentities[$idpentity->metadataurl] = [];
         }
 
-        $idpentities[$idpentity->metadataurl][$idpentity->md5entityid] = ($asarray) ? (array) $idpentity : $idpentity;
+        $idpentities[$idpentity->metadataurl][$idpentity->md5id] = ($asarray) ? (array) $idpentity : $idpentity;
     }
 
     return $idpentities;

--- a/test.php
+++ b/test.php
@@ -55,7 +55,7 @@ if (!empty($idp)) {
 
 if (empty($SESSION->saml2idp)) {
     // Specify the default IdP to use.
-    $SESSION->saml2idp = reset($saml2auth->metadataentities)->md5entityid;
+    $SESSION->saml2idp = reset($saml2auth->metadataentities)->md5id;
     echo '<p>Setting IdP to default</p>';
 }
 
@@ -71,8 +71,8 @@ $auth = new SimpleSAML\Auth\Simple($saml2auth->spname);
 foreach ($saml2auth->metadataentities as $idpentity) {
     echo '<hr>';
     echo "<h4>IDP: $idpentity->entityid</h4>";
-    echo "<p>md5: $idpentity->md5entityid</p>";
-    echo "<p>check: " . md5($idpentity->entityid) . "</p>";
+    echo "<p>md5: $idpentity->md5id</p>";
+    echo "<p>check: " . md5($idpentity->id) . "</p>";
 }
 
 if ($logout) {

--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -190,9 +190,9 @@ class auth_saml2_test extends \advanced_testcase {
         // Name attribute is matching defaultname.
         $this->assertEquals($entity1->defaultname, reset($auth->metadataentities)->name);
 
-        // Encoded entityid present as an attribute as well as the key.
-        $this->assertArrayHasKey(md5($entity1->entityid), $auth->metadataentities);
-        $this->assertEquals(md5($entity1->entityid), reset($auth->metadataentities)->md5entityid);
+        // Encoded id present as an attribute as well as the key.
+        $this->assertArrayHasKey(md5($entity1->id), $auth->metadataentities);
+        $this->assertEquals(md5($entity1->id), reset($auth->metadataentities)->md5id);
 
         // Multiidp flag is false.
         $reflector = new \ReflectionClass($auth);
@@ -232,19 +232,19 @@ class auth_saml2_test extends \advanced_testcase {
         if (method_exists($this, 'assertEqualsCanonicalizing')) {
             // Check entity name.
             $this->assertEqualsCanonicalizing(['Login 1', $entity1->defaultname], array_column($auth->metadataentities, 'name'));
-            // Encoded entityid present as an attribute as well as the key.
-            $this->assertEqualsCanonicalizing([md5($entity1->entityid), md5($entity3->entityid)],
-                array_column($auth->metadataentities, 'md5entityid'));
-            $this->assertEqualsCanonicalizing([md5($entity1->entityid), md5($entity3->entityid)],
+            // Encoded id present as an attribute as well as the key.
+            $this->assertEqualsCanonicalizing([md5($entity1->id), md5($entity3->id)],
+                array_column($auth->metadataentities, 'md5id'));
+            $this->assertEqualsCanonicalizing([md5($entity1->id), md5($entity3->id)],
                 array_keys($auth->metadataentities));
         } else {
             // Check entity name.
             $this->assertEquals(['Login 1', $entity1->defaultname],
                 array_column($auth->metadataentities, 'name'), '', 0, 10, true);
-            // Encoded entityid present as an attribute as well as the key.
-            $this->assertEquals([md5($entity1->entityid), md5($entity3->entityid)],
-                array_column($auth->metadataentities, 'md5entityid'), '', 0, 10, true);
-            $this->assertEquals([md5($entity1->entityid), md5($entity3->entityid)],
+            // Encoded id present as an attribute as well as the key.
+            $this->assertEquals([md5($entity1->id), md5($entity3->id)],
+                array_column($auth->metadataentities, 'md5id'), '', 0, 10, true);
+            $this->assertEquals([md5($entity1->id), md5($entity3->id)],
                 array_keys($auth->metadataentities), '', 0, 10, true);
         }
 
@@ -258,7 +258,7 @@ class auth_saml2_test extends \advanced_testcase {
         $property = $reflector->getParentClass()->getProperty('defaultidp');
         $property->setAccessible(true);
         $this->assertNotNull($property->getValue($auth));
-        $this->assertEquals($auth->metadataentities[md5($entity3->entityid)], $property->getValue($auth));
+        $this->assertEquals($auth->metadataentities[md5($entity3->id)], $property->getValue($auth));
     }
 
     public function test_loginpage_idp_list(): void {
@@ -280,7 +280,7 @@ class auth_saml2_test extends \advanced_testcase {
         $this->assertInstanceOf(\moodle_url::class, $url);
         $this->assertEquals('/moodle/auth/saml2/login.php', $url->get_path());
         $this->assertEquals('/', $url->get_param('wants'));
-        $this->assertEquals(md5($entity1->entityid), $url->get_param('idp'));
+        $this->assertEquals(md5($entity1->id), $url->get_param('idp'));
         $this->assertEquals('off', $url->get_param('passive'));
 
         // Wantsurl is pointing to auth/saml2/login.php.

--- a/tests/setting_idpmetadata_test.php
+++ b/tests/setting_idpmetadata_test.php
@@ -100,8 +100,9 @@ class setting_idpmetadata_test extends advanced_testcase {
         foreach ($metadataidps as $metadataurl => $idps) {
             self::assertSame('xml', $metadataurl);
 
-            $idp1md5 = md5('https://idp1.example.org/idp/shibboleth');
-            $idp2md5 = md5('https://idp2.example.org/idp/shibboleth');
+            $idpids = array_values(array_map(fn($idp) => $idp->id, $idps));
+            $idp1md5 = md5($idpids[0]);
+            $idp2md5 = md5($idpids[1]);
 
             self::assertTrue(array_key_exists($idp1md5, $idps));
             self::assertTrue(array_key_exists($idp2md5, $idps));

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024020200;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024020200;    // Match release exactly to version.
+$plugin->version   = 2024020201;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024020201;    // Match release exactly to version.
 $plugin->requires  = 2017051509;    // Requires PHP 7, 2017051509 = T12. M3.3
                                     // Strictly we require either Moodle 3.5 OR
                                     // we require Totara 3.3, but the version number

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023100300;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2023100300;    // Match release exactly to version.
+$plugin->version   = 2024020200;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024020200;    // Match release exactly to version.
 $plugin->requires  = 2017051509;    // Requires PHP 7, 2017051509 = T12. M3.3
                                     // Strictly we require either Moodle 3.5 OR
                                     // we require Totara 3.3, but the version number


### PR DESCRIPTION
Fix for #1 

Notable changes:

* Changed use of internal array key by from non unique database field `entityid` to unique database field `id`